### PR TITLE
feat: Make sort orders optional

### DIFF
--- a/sort_orders.rb
+++ b/sort_orders.rb
@@ -25,25 +25,40 @@
 # ]
 module AlgoliaShopify
   class SortOrderGenerator
-    def initialize(attributes:)
+    def initialize(attributes:, include_desc_sort_orders: false)
       @attributes = attributes
+      @include_desc_sort_orders = include_desc_sort_orders
     end
 
     def to_sort_orders
-      @attributes.map do |o|
-        {
+      selected_attributes = @attributes.select(&:should_create_sort_order!)
+
+      selected_attributes.map do |o|
+        sort_order = {
           title: o[:title],
           key: "unique_key_#{o[:id]}",
+          metadata: "created_at: #{Time.now}",
           asc: {
             active: false,
             title: "#{o[:title]} asc"
-          },
-          desc: {
+          }
+        }
+
+        if @include_desc_sort_orders
+          sort_order[:desc] = {
             active: false,
             title: "#{o[:title]} desc"
           }
-        }
+        end
+
+        sort_order
       end
+    end
+
+    private
+
+    def should_create_sort_order!(attribute)
+      attribute[:skip] != true
     end
   end
 end

--- a/spec/sort_orders_spec.rb
+++ b/spec/sort_orders_spec.rb
@@ -2,15 +2,18 @@ require_relative '../sort_orders'
 
 RSpec.describe AlgoliaShopify::SortOrderGenerator do
   context '#generate_sort_orders' do
+    let(:sample_timestamp) { 'sample_timestamp' }
     let(:sample_input) do
       [
         {
           title: 'recently_ordered',
-          id: 1
+          id: 1,
+          skip: false
         },
         {
           title: 'discounted',
-          id: 2
+          id: 2,
+          skip: true
         }
       ]
     end
@@ -19,6 +22,7 @@ RSpec.describe AlgoliaShopify::SortOrderGenerator do
         {
           title: 'recently_ordered',
           key: "unique_key_1",
+          metadata: "created_at: #{sample_timestamp}",
           asc: {
             active: false,
             title: "recently_ordered asc"
@@ -27,22 +31,19 @@ RSpec.describe AlgoliaShopify::SortOrderGenerator do
             active: false,
             title: "recently_ordered desc"
           }
-        },
-        {
-          title: 'discounted',
-          key: "unique_key_2",
-          asc: {
-            active: false,
-            title: "discounted asc"
-          },
-          desc: {
-            active: false,
-            title: "discounted desc"
-          }
         }
       ]
     end
-    let(:class_instance) { described_class.new(attributes: sample_input) }
+    let(:class_instance) do
+      described_class.new(
+        attributes: sample_input,
+        include_desc_sort_orders: true
+      )
+    end
+
+    before do
+      allow(Time).to receive(:now).and_return(sample_timestamp)
+    end
 
     it 'returns the sort orders in the correct format' do
       result = class_instance.to_sort_orders


### PR DESCRIPTION
# Make sort orders optional

This PR adds an option to decide whether each attribute should be selected as a sort order.
A new attribute `sort_order` has to be provided for each attribute.

It also adds an ability to configure whether descending sort orders should be created or not.

Additionally, another attribute called `metadata` has been added to the newly created sort orders.
This will have the value of the current timestamp.